### PR TITLE
fix(hooks): honor pre-commit filenames in values-check & avoid set -e abort

### DIFF
--- a/scripts/hooks/values-check.sh
+++ b/scripts/hooks/values-check.sh
@@ -6,8 +6,14 @@ set -e
 
 echo "🔍 Validating values.yaml files..."
 
-# Get changed values.yaml files
-changed_values=$(git diff --cached --name-only | grep "values\.yaml$")
+# pre-commit passes the matched files as arguments; fall back to staged
+# values.yaml when invoked directly (e.g. as a manual git hook with no args).
+# The `|| true` keeps `set -e` from aborting when grep finds no match.
+if [ "$#" -gt 0 ]; then
+    changed_values=$(printf '%s\n' "$@" | grep "values\.yaml$" || true)
+else
+    changed_values=$(git diff --cached --name-only | grep "values\.yaml$" || true)
+fi
 
 if [ -z "$changed_values" ]; then
     echo "✅ No values.yaml changes detected"


### PR DESCRIPTION
values-check.sh read `git diff --cached --name-only` and, under `set -e`, the assignment aborted the script the moment grep matched nothing (e.g. when run via `pre-commit run --all-files` with nothing staged) — printing only the header and exiting 1.

pre-commit already passes the matched values.yaml paths as arguments (pass_filenames defaults to true), so use "$@" when present and fall back to staged files otherwise. Add `|| true` so an empty match no longer trips `set -e`. Behaviour verified for: args passed, staged-only, clean tree (graceful skip), and invalid YAML (still rejected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the values validation pre-commit hook with improved file filtering logic and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truvami/helm/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->