### PR TITLE
ci: migrate GitHub Pages to Actions-based deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,3 +104,48 @@ jobs:
             echo "Pushing $pkg to oci://ghcr.io/truvami/helm"
             helm push "$pkg" oci://ghcr.io/truvami/helm
           done
+
+  # Publishes the Helm repo index (the gh-pages branch) to GitHub Pages using the
+  # GitHub Actions deployment pipeline. This replaces the legacy "deploy from a
+  # branch" build, whose auto-injected pages-build-deployment workflow started
+  # failing with "401 Requires authentication". The first run flips the Pages
+  # build type from "legacy" to "workflow" via configure-pages enablement.
+  deploy-pages:
+    needs: charts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    # Avoid overlapping Pages deployments; let an in-progress one finish.
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Stage site content
+        run: |
+          mkdir -p _site
+          rsync -a --exclude='.git' gh-pages/ _site/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

GitHub Pages for `helm.truvami.com` started failing on 2026-06-10 with:

```
Error: Failed to create deployment (status: 401) ... HttpError: Requires authentication
```

The error comes from GitHub's **auto-injected** `pages-build-deployment` workflow that runs on every `gh-pages` push (legacy "deploy from a branch" mode). All config was verified healthy (Pages enabled, valid cert, `gh-pages` allowed by the `github-pages` environment branch policy, `write` default token perms). It worked on 2026-06-09 and broke on 2026-06-10 with no config change — the legacy deploy pipeline appears to be in a wedged state (the latest legacy build is stuck in `building`).

## Fix

Migrate Pages publishing from the legacy branch build to the **GitHub Actions** deployment pipeline. A new `deploy-pages` job in `release.yml`:

- runs after `charts` (so it deploys the freshly-updated `index.yaml`)
- checks out `gh-pages`, stages it into `_site` (excluding `.git`)
- `actions/configure-pages@v5` with `enablement: true` — flips the Pages build type `legacy` → `workflow` on first run
- `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`

The custom domain (`helm.truvami.com`) and cert are stored at the repo level and persist across the build-type change; `CNAME` is also retained in the uploaded artifact.

## After merge

- The legacy `pages-build-deployment` workflow stops auto-running once the build type is `workflow`.
- If `configure-pages` enablement does not auto-flip the existing legacy site, set **Settings → Pages → Source → GitHub Actions** once, then re-run the workflow.